### PR TITLE
Fix histogram -1 shift for in_use_count and free_count metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for `hackney_telemetry`
 
+## 0.1.1
+
+Minor update.
+
+### 1. Bug fixes
+  - Fix histogram values shift for `in_use_count` and `free_count metrics`
+
 ## 0.1.0
 
 First version!

--- a/src/hackney_telemetry.app.src
+++ b/src/hackney_telemetry.app.src
@@ -3,7 +3,7 @@
   hackney_telemetry,
   [
     {description, "An adapter to export hackney metrics to telemetry"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {mod, {hackney_telemetry_app, []}},
     {applications, [kernel, stdlib, telemetry]},
@@ -18,7 +18,7 @@
         "include",
         "rebar.config",
         "rebar.lock",
-        "CHANGELOG",
+        "CHANGELOG.md",
         "CODE_OF_CONDUCT.md",
         "README.md",
         "LICENSE",

--- a/src/hackney_telemetry.erl
+++ b/src/hackney_telemetry.erl
@@ -126,9 +126,13 @@ update_histogram(Metric, Fun) when is_function(Fun) ->
 % For these metrics, we fix their value by adding +1.
 %
 % Reference: https://github.com/benoitc/hackney/blob/592a00720cd1c8eb1edb6a6c9c8b8a4709c8b155/src/hackney_pool.erl%L597-L604
-update_histogram([hackney_pool, _, MetricName] = Metric, Value)
-when MetricName == in_use_count, MetricName == free_count ->
-  hackney_telemetry_worker:update(Metric, Value + 1, fun replace/2);
+update_histogram([hackney_pool, _, MetricName] = Metric, Value) ->
+  FixedValue =
+    case lists:member(MetricName, [in_use_count, free_count]) of
+      true -> Value + 1;
+      false -> Value
+    end,
+  hackney_telemetry_worker:update(Metric, FixedValue, fun replace/2);
 
 update_histogram(Metric, Value) -> hackney_telemetry_worker:update(Metric, Value, fun replace/2).
 


### PR DESCRIPTION
## Motivation

Hackney has shift of -1 for pool metrics `in_use_count` and `free_count` and the function guards in place for histograms were wrong.
<!--
Describe _why_ are you creating this PR.

Why is this change required? What problem does it solve?

Examples:

- Fixes a bug that prevents telemetry reports when numbers are not numbers
- Add support for host metrics
-->

## Overview

- Change `hackney_telemetry:update_histogram/2` to check the metric name inside a `case` statement
- Add tests
- Bump version

<!--
Describe _what_ are you changing

Examples:
 - Add one more default worker to `hackney_telemetry_sup`
 - Handles exceptions when trying to sum non numbers
-->
