### PR TITLE
Fix hex broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@
 
 The following metrics are exported by this library to telemetry. They will represent the last known value of the metric. They are based on [hackney's metrics](https://github.com/benoitc/hackney#metrics).
 
-|Metric | Tags | Meaning |
-|-|-|-|
-|`hackney.nb_requests`       | - | Current number of requests
-|`hackney.finished_requests` | - | Total number of finished requests
-|`hackney.total_requests`    | - |Total number of requests
-|`hackney_pool.free_count`| pool | Number of free sockets in a connection pool
-|`hackney_pool.in_use_count`| pool | Number of busy sockets in a connection pool
-|`hackney_pool.no_socket`| pool | Count of new connections
-|`hackney_pool.queue_count`| pool | Number of requests waiting for a connection in a pool
-|`hackney_pool.take_rate`| pool | Rate at which a connection is retrieved from the pool
+| Metric                      | Tags | Meaning                                               |
+| --------------------------- | ---- | ----------------------------------------------------- |
+| `hackney.nb_requests`       | -    | Current number of requests                            |
+| `hackney.finished_requests` | -    | Total number of finished requests                     |
+| `hackney.total_requests`    | -    | Total number of requests                              |
+| `hackney_pool.free_count`   | pool | Number of free sockets in a connection pool           |
+| `hackney_pool.in_use_count` | pool | Number of busy sockets in a connection pool           |
+| `hackney_pool.no_socket`    | pool | Count of new connections                              |
+| `hackney_pool.queue_count`  | pool | Number of requests waiting for a connection in a pool |
+| `hackney_pool.take_rate`    | pool | Rate at which a connection is retrieved from the pool |
 
 *Note: metrics for hosts are still not supported*.
 
@@ -58,9 +58,11 @@ end
 ```
 
 ### Configuring Hackney
+
 In your application config you need to set hackney's `mod_metrics`:
 
 **Erlang**
+
 ```erlang
 {hackney, [{mod_metrics, hackney_telemetry}]}
 ```
@@ -74,15 +76,18 @@ config :hackney, mod_metrics: :hackney_telemetry
 ### Options
 
 #### Report interval
+
 By default, workers will report data to telemetry every 1000 milliseconds. You
 can change that by setting the `report_interval` option:
 
 **Erlang**
+
 ```erlang
 {hackney_telemetry, [{report_interval, 2_000}]}
 ```
 
 **Elixir**
+
 ```elixir
 config :hackney_telemetry, report_interval: 2_000
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following metrics are exported by this library to telemetry. They will repre
 
 ## Installation
 
-Install it from [Hex](https://hex.pm/packages/hackney_telemetry) or [Github](github.com/TheRealReal/hackney_telemetry).
+Install it from [Hex](https://hex.pm/packages/hackney_telemetry) or [Github](https://github.com/TheRealReal/hackney_telemetry).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Tests](https://github.com/TheRealReal/hackney_telemetry/actions/workflows/ci.yml/badge.svg)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 # hackney_telemetry
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following metrics are exported by this library to telemetry. They will repre
 
 ## Installation
 
-Install it from [Hex](hex.pm/TheRealReal/hackney_telemetry) or [Github](github.com/TheRealReal/hackney_telemetry).
+Install it from [Hex](https://hex.pm/packages/hackney_telemetry) or [Github](github.com/TheRealReal/hackney_telemetry).
 
 ## Usage
 


### PR DESCRIPTION
## Motivation
<!--
Describe _why_ are you creating this PR.

Why is this change required? What problem does it solve?

Examples:

- Fixes a bug that prevents telemetry reports when numbers are not numbers
- Add support for host metrics
-->
Improving documentation

## Overview
<!--
Describe _what_ are you changing

Examples:
 - Add one more default worker to `hackney_telemetry_sup`
 - Handles exceptions when trying to sum non numbers
-->
- Fixes the broken link for hex.pm
- Improves markdown style for README.md file