### PR TITLE
Add per-host metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## In development
+
+- Added per-host telemetry metrics (https://github.com/TheRealReal/hackney_telemetry/pull/7)
+
 ## [0.1.2] - 2022-09-19
+
 ### Changed
+
 - Update docs
 - Build docs with ex_doc
 - Update specs to successfully run Dialyzer
@@ -14,13 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.1] - 2021-12-10
 
 ### Changed
+
 Minor update.
 
 ### Fixed
+
 - Fix histogram values shift for `in_use_count` and `free_count metrics`
 
 ## [0.1.0] - 2021-12-08
 
 ## Added
+
 - First version!
 - Metrics collector for hackney global and pool metrics

--- a/README.md
+++ b/README.md
@@ -18,16 +18,22 @@ so we need to transform the metrics data before reporting it.
 
 The following metrics are exported by this library to telemetry.
 
-| Metric                      | Tags | Meaning                                               |
-| --------------------------- | ---- | ----------------------------------------------------- |
-| `hackney.nb_requests`       | -    | Current number of requests                            |
-| `hackney.finished_requests` | -    | Total number of finished requests                     |
-| `hackney.total_requests`    | -    | Total number of requests                              |
-| `hackney_pool.free_count`   | pool | Number of free sockets in a connection pool           |
-| `hackney_pool.in_use_count` | pool | Number of busy sockets in a connection pool           |
-| `hackney_pool.no_socket`    | pool | Count of new connections                              |
-| `hackney_pool.queue_count`  | pool | Number of requests waiting for a connection in a pool |
-| `hackney_pool.take_rate`    | pool | Rate at which a connection is retrieved from the pool |
+| Metric                         | Tags | Meaning                                               |
+| ------------------------------ | ---- | ----------------------------------------------------- |
+| `hackney.nb_requests`          | -    | Current number of requests                            |
+| `hackney.finished_requests`    | -    | Total number of finished requests                     |
+| `hackney.total_requests`       | -    | Total number of requests                              |
+| `hackney_pool.free_count`      | pool | Number of free sockets in a connection pool           |
+| `hackney_pool.in_use_count`    | pool | Number of busy sockets in a connection pool           |
+| `hackney_pool.no_socket`       | pool | Count of new connections                              |
+| `hackney_pool.queue_count`     | pool | Number of requests waiting for a connection in a pool |
+| `hackney_pool.take_rate`       | pool | Rate at which a connection is retrieved from the pool |
+| `hackney_host.nb_requests`     | host | Number of running requests per host                   |
+| `hackney_host.request_time`    | host | Request time per host                                 |
+| `hackney_host.connect_time`    | host | Connect time per host                                 |
+| `hackney_host.response_time`   | host | Response time per host                                |
+| `hackney_host.connect_timeout` | host | Number of connect timeout per host                    |
+| `hackney_host.connect_error`   | host | Number of timeout errors per host                     |
 
 This module implements all the callbacks required by `hackney_metrics` but it does
 not support host metrics.
@@ -126,7 +132,13 @@ defmodule YourApplcation.Telemetry do
     last_value("hackney_pool.in_use_count", tags: [:pool]),
     last_value("hackney_pool.no_socket", tags: [:pool]),
     last_value("hackney_pool.queue_count", tags: [:pool]),
-    last_value("hackney_pool.take_rate", tags: [:pool])
+    last_value("hackney_pool.take_rate", tags: [:pool]),
+    last_value("hackney_host.nb_requests", tags: [:host]),
+    last_value("hackney_host.request_time", tags: [:host]),
+    last_value("hackney_host.connect_time", tags: [:host]),
+    last_value("hackney_host.response_time", tags: [:host]),
+    last_value("hackney_host.connect_timeout", tags: [:host]),
+    last_value("hackney_host.connect_error", tags: [:host])
   ]
   end
 end
@@ -160,7 +172,7 @@ rebar3 steamroll
 
 ## Code of Conduct
 
-This project  Contributor Covenant version 2.1. Check [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) file for more information.
+This project Contributor Covenant version 2.1. Check [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) file for more information.
 
 ## License
 

--- a/include/hackney_telemetry_worker.hrl
+++ b/include/hackney_telemetry_worker.hrl
@@ -1,7 +1,7 @@
 -record(
   worker_state,
   {
-    value :: any(),
+    value :: map(),
     report_interval :: non_neg_integer(),
     telemetry_settings :: {[atom(), ...], atom(), map()}
   }

--- a/src/hackney_telemetry_sup.erl
+++ b/src/hackney_telemetry_sup.erl
@@ -17,14 +17,17 @@
 
 start_link() -> supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
+-define(PER_HOST, [nb_requests, request_time, connect_time, response_time, connect_timeout, connect_error]).
+
 init([]) ->
   SupFlags = #{strategy => one_for_one, intensity => 0, period => 1},
   ChildSpecs =
     [
-      hackney_telemetry_worker:child_spec([{metric, [hackney, nb_requests]}]),
-      hackney_telemetry_worker:child_spec([{metric, [hackney, total_requests]}]),
-      hackney_telemetry_worker:child_spec([{metric, [hackney, finished_requests]}])
-    ],
+      hackney_telemetry_worker:child_spec([{metric, [hackney, Sub]}])
+     || Sub <- [nb_requests, total_requests, finished_requests]]
+        ++ [
+      hackney_telemetry_worker:child_spec([{metric, [hackney_host, Sub]}])
+     || Sub <- ?PER_HOST],
   {ok, {SupFlags, ChildSpecs}}.
 
 %%% @doc Start worker for the given metric under this supervisor.


### PR DESCRIPTION
Under the `hackney_host` Telemetry key, host-based metrics are now exposed. The hostnames themselves are tagged as Telemetry metadata.

Note that the measurement value of the worker is now flushed after every call to `report()`, which means that the results sent to
telemetry are now effectively binned to the report interval (if any). This is done to prevent a growing worker state in the case of connections to many hosts.

