### PR TITLE
chore: specify telemetry version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
-{deps, [telemetry]}.
+{deps, [{telemetry, "~> 1.0"}]}.
 
 {project_plugins, [steamroller, rebar3_hex, rebar3_ex_doc]}.
 


### PR DESCRIPTION
## Motivation

<!--
Describe _why_ are you creating this PR.

Why is this change required? What problem does it solve?

Examples:

- Fixes a bug that prevents telemetry reports when numbers are not numbers
- Add support for host metrics
-->
If we start a new elixir application with the following deps:

```elixir
  defp deps do
    [
      {:telemetry, "~> 1.1.0"},
      {:httpoison, "~> 1.8.2"}
    ]
  end
```
We won't be able to add `:hackney_telemetry`, since it only accept `:telemetry` at version 1.0.0.

![Screenshot from 2023-01-10 10-08-14](https://user-images.githubusercontent.com/8541630/211560195-88d2ebd5-c037-4c6f-86fa-43c69c407b65.png)


## Overview

<!--
Describe _what_ are you changing

Examples:
 - Add one more default worker to `hackney_telemetry_sup`
 - Handles exceptions when trying to sum non numbers
-->
